### PR TITLE
make CleanLogs.sh available inside the container

### DIFF
--- a/docker/crabtaskworker/install.sh
+++ b/docker/crabtaskworker/install.sh
@@ -7,8 +7,8 @@ env
         cd /data/srv/TaskManager
 
         touch /data/srv/condor_config
-        curl --remote-name-all https://raw.githubusercontent.com/dmwm/CRABServer/master/src/script/Deployment/TaskWorker/{start.sh,env.sh,stop.sh}
-        chmod 750 start.sh env.sh stop.sh
+        curl --remote-name-all https://raw.githubusercontent.com/dmwm/CRABServer/master/src/script/Deployment/TaskWorker/{start.sh,env.sh,stop.sh,CleanLogs.sh}
+        chmod 750 start.sh env.sh stop.sh CleanLogs.sh
 
         set -x
         echo 'Setting enviroment'


### PR DESCRIPTION
I find very useful when testing things on test/dev/preprod TW's were paste logs are not important